### PR TITLE
Allow direct access to `initJoins`

### DIFF
--- a/src/Relations/HasManyViaMany.php
+++ b/src/Relations/HasManyViaMany.php
@@ -223,7 +223,7 @@ class HasManyViaMany extends Relation
      * Handle predefined joins array
      * @return void
      */
-    protected function initJoins()
+    public function initJoins()
     {
         // Store existing joins and clear list
         $joins = !empty($this->query->getQuery()->joins) ? $this->query->getQuery()->joins : [];
@@ -243,6 +243,8 @@ class HasManyViaMany extends Relation
 
         // Re-add existing joins to the end (we need to ensure relation joins run first)
         $this->query->getQuery()->joins = array_merge($this->query->getQuery()->joins, $joins);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Edge case where creating custom methods on an overwritten builder to replace get. For example a rawGet method.
In this case the logic to generate joins is not fired.

This change makes `initJoins` public so it can be called as a work around, although it is not recommended to avoid the normal model methods as accessing this directly may cause unexpected behaviour.  