### PR TITLE
Allow using custom inertModels in "bonus" relationships.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,14 @@
     "require": {
         "illuminate/database": "^8 || ^9 || ^10 | ^11"
     },
+    "scripts": {
+        "test": [
+            "vendor/bin/phpunit"
+        ],
+        "lint": [
+            "vendor/bin/phpcs"
+        ]
+    },
     "require-dev": {
         "phpunit/phpunit": "^9.5 || ^9.6",
         "orchestra/testbench": "^6",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Application Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="DB_CONNECTION" value="testing"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Application Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="DB_CONNECTION" value="testing"/>
+  </php>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ A selection of weird & wonderful additional relation types for laravel's eloquen
 Many of these are experimental and may behave in unexpected & none standard ways.
 
 On the bright side - it's tested!       
-[![Build Status](https://travis-ci.org/thybag/bonus-laravel-relations.svg?branch=master)](https://travis-ci.org/thybag/bonus-laravel-relations)
+![Build Status](https://github.com/thybag/bonus-laravel-relations/actions/workflows/test.yml/badge.svg)
  
 All licensed under the MIT license.
 

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,9 @@ All licensed under the MIT license.
 
 The relation traits can also be added individually if you prefer that.
 
+* Run tests with `composer test`
+* Run lint with `composer lint`
+
 # Relations 
 
 ### BelongsToMorph
@@ -75,3 +78,9 @@ public function latestRating()
     return $this->belongsToOne(Rating::class, 'shop_rating')->latest('created_at');
 }
 ```
+
+# InertModel
+
+As the relationships `HasMethod` and `HasAggregate` don't return a traditional model from the database, a special model called type `InertModel` is used. This allows the relationship to fill the model with arbitrary attributes without the risk of causing unexpected behavior.
+
+If you would like to use a custom InertModel rather than the one provided, create a config called `bonus-laravel-relationships.php` in your config folder, then set the value `inertModel` with the class path to the model you would like to use instead. I would recommend whatever model you use inherits from the base IntertModel to avoid unexpected behavior.

--- a/src/Relations/HasAggregate.php
+++ b/src/Relations/HasAggregate.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use thybag\BonusLaravelRelations\Traits\InertModelTrait;
 
 /**
  * Get Aggregate query data as a relation.
@@ -13,6 +14,8 @@ use Illuminate\Database\Eloquent\Relations\Relation;
  */
 class HasAggregate extends Relation
 {
+    use InertModelTrait;
+
     // Key to link relation on
     protected $relation_key = null;
     // Aggregate sql - can be supplied by selectRaw instead.
@@ -28,6 +31,11 @@ class HasAggregate extends Relation
      */
     public function __construct(Builder $query, Model $parent, string $relation_key, string $sql = null)
     {
+        // The builder provided is for an instance of the real model. We want to swap this out for our
+        // inert model in order to return custom attributes based on the query. To do this we grab a copy
+        // of our InertModel and give it the table from the real one.
+        $query = $this->getInertModelInstance()->setTable($query->getModel()->getTable())->newQuery();
+
         // Set relation key
         $this->relation_key = $relation_key;
         $this->aggregate_sql = $sql;

--- a/src/Relations/HasMethod.php
+++ b/src/Relations/HasMethod.php
@@ -5,8 +5,8 @@ namespace thybag\BonusLaravelRelations\Relations;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
-use thybag\BonusLaravelRelations\Models\InertModel;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use thybag\BonusLaravelRelations\Traits\InertModelTrait;
 
 /**
  * Allows a method to be returned as if it was a relation.
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Relations\Relation;
  */
 class HasMethod extends Relation
 {
+    use InertModelTrait;
+
     protected $method;
     protected $parent;
     protected $withs = [];
@@ -31,17 +33,6 @@ class HasMethod extends Relation
         $this->parent = $parent;
         $this->method = $method;
         $this->returnCollection = $collection;
-    }
-
-    /**
-     * Get basic model instance to return as result.
-     *
-     * @return Model
-     */
-    protected function getInertModelInstance()
-    {
-        // @todo allow custom model via config
-        return new InertModel();
     }
 
     /**

--- a/src/Traits/HasAggregateRelationTrait.php
+++ b/src/Traits/HasAggregateRelationTrait.php
@@ -18,13 +18,12 @@ trait HasAggregateRelationTrait
      */
     public function hasAggregate(string $related, string $relation_key = null, string $sql = null)
     {
-        $base = new $related;
-        $instance = new InertModel();
+        $instance = new $related;
 
         if (empty($relation_key)) {
             $relation_key = $this->getForeignKey();
         }
 
-        return new HasAggregate($instance->setTable($base->getTable())->newQuery(), $this, $relation_key, $sql);
+        return new HasAggregate($instance->newQuery(), $this, $relation_key, $sql);
     }
 }

--- a/src/Traits/InertModelTrait.php
+++ b/src/Traits/InertModelTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace thybag\BonusLaravelRelations\Traits;
+
+use thybag\BonusLaravelRelations\Models\InertModel;
+
+trait InertModelTrait
+{
+    /**
+     * Get basic model instance to return as result.
+     *
+     * @return Model
+     */
+    protected function getInertModelInstance()
+    {
+        // Attempt to use provided inertModel if one is set.
+        $model = config('bonus-laravel-relationships.inertModel');
+        return !empty($model) ? new $model() : new InertModel();
+    }
+}

--- a/tests/HasMethodTest.php
+++ b/tests/HasMethodTest.php
@@ -2,6 +2,7 @@
 namespace thybag\BonusLaravelRelations\Test;
 
 use Orchestra\Testbench\TestCase;
+use thybag\BonusLaravelRelations\Test\Models\CustomInert;
 use thybag\BonusLaravelRelations\Test\Models\HasMethodTestModel;
 
 class TestHasMethod extends TestCase
@@ -76,5 +77,26 @@ class TestHasMethod extends TestCase
         $test = HasMethodTestModel::make();
         $test->load('callbackAsObject');
         $this->assertEquals('one', $test->callbackAsObject->a);
+    }
+
+    public function testHasMethodWithCustomInertModel()
+    {
+        // Swap base model to be used by relationship
+        config(['bonus-laravel-relationships.inertModel' => CustomInert::class]);
+        $test = HasMethodTestModel::make([
+            'amount' => 5,
+            'value' => 2,
+            'product' => 'cake'
+        ]);
+
+        // Check we got custom class
+        $this->assertEquals(CustomInert::class, get_class($test->asMethod));
+
+        // Check custom model method exists
+        $this->assertEquals('hi', $test->asMethod->hello());
+
+        // Check data still happy
+        $this->assertEquals('Cake', $test->asMethod->product);
+        $this->assertEquals(10, $test->asMethod->totalValue);
     }
 }

--- a/tests/Models/CustomInert.php
+++ b/tests/Models/CustomInert.php
@@ -1,0 +1,15 @@
+<?php
+namespace thybag\BonusLaravelRelations\Test\Models;
+
+use thybag\BonusLaravelRelations\Models\InertModel;
+
+/**
+ * Test mode to checkl replacement of inertModel in relationships
+ */
+class CustomInert extends InertModel
+{
+    public function hello()
+    {
+        return "hi";
+    }
+}


### PR DESCRIPTION
Key changes.
* Allow class path in config `bonus-laravel-relationships.inertModel` to override the inertModel used for hasAggregate and hasMethod's.
* Refactor codebase to facilitate the above, creating new InertModelTrait to handle grabbing either inertModel or its override.
* Add lint/test scripts to composer so its easier to find/run these.
* Add tests for new behaviour
* Update readme to explain new behaviour
* Update phpunit xml to latest