### PR TITLE
Aggregate relationships can now define post-proccess steps via withCallback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
         ],
         "lint": [
             "vendor/bin/phpcs"
+        ],
+        "lint-fix": [
+            "vendor/bin/phpcbf"
         ]
     },
     "require-dev": {

--- a/src/Relations/HasAggregate.php
+++ b/src/Relations/HasAggregate.php
@@ -23,16 +23,17 @@ class HasAggregate extends Relation
     protected $relation_key = null;
     // Aggregate sql - can be supplied by selectRaw instead.
     protected $aggregate_sql = '';
-
+    // Callback function
     protected ?Closure $callback = null;
 
     /**
      * Set up relation
      *
-     * @param Builder
-     * @param Model
-     * @param string
-     * @param string|null
+     * @param Builder $query - Query
+     * @param Model $parent - Parent model
+     * @param string relation_key - relationship column
+     * @param string|null $sql - Raw SQL equivalent of whereRaw
+     * @param string|null $returnModel - Return model - this should be a class string
      */
     public function __construct(Builder $query, Model $parent, string $relation_key, ?string $sql = null, ?string $returnModel = null)
     {

--- a/src/Relations/HasAggregate.php
+++ b/src/Relations/HasAggregate.php
@@ -2,6 +2,7 @@
 
 namespace thybag\BonusLaravelRelations\Relations;
 
+use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\Expression;
@@ -23,6 +24,8 @@ class HasAggregate extends Relation
     // Aggregate sql - can be supplied by selectRaw instead.
     protected $aggregate_sql = '';
 
+    protected ?Closure $callback = null;
+
     /**
      * Set up relation
      *
@@ -31,12 +34,12 @@ class HasAggregate extends Relation
      * @param string
      * @param string|null
      */
-    public function __construct(Builder $query, Model $parent, string $relation_key, string $sql = null)
+    public function __construct(Builder $query, Model $parent, string $relation_key, ?string $sql = null, ?string $returnModel = null)
     {
         // The builder provided is for an instance of the real model. We want to swap this out for our
         // inert model in order to return custom attributes based on the query. To do this we grab a copy
-        // of our InertModel and give it the table from the real one.
-        $query = $this->getInertModelInstance()->setTable($query->getModel()->getTable())->newQuery();
+        // of our InertModel and give it the table from the real one. A $returnModel can be used instead.
+        $query = $this->getInertModelInstance($returnModel)->setTable($query->getModel()->getTable())->newQuery();
 
         // Set relation key
         $this->relation_key = $relation_key;
@@ -120,7 +123,7 @@ class HasAggregate extends Relation
      */
     public function getResults()
     {
-        return $this->first();
+        return $this->runModelCallback($this->first());
     }
 
     /**
@@ -129,15 +132,32 @@ class HasAggregate extends Relation
      * @param  Collection $results
      * @return array
      */
-    protected function buildDictionary(Collection $results)
+    protected function buildDictionary(Collection $results): array
     {
         $dictionary = [];
 
         foreach ($results as $result) {
-            $dictionary[$result->id] =  $result;
+            // If we have a callback, apply it to each result
+            $dictionary[$result->id] = $this->runModelCallback($result);
         }
 
         return $dictionary;
+    }
+
+    protected function runModelCallback(?Model $model): ?Model
+    {
+        // No result
+        if (empty($model)) {
+            return null;
+        }
+
+        // If we don't have a callback
+        $callback = $this->callback;
+        if (empty($callback)) {
+            return $model;
+        }
+
+        return $callback($model);
     }
 
     /**
@@ -172,5 +192,17 @@ class HasAggregate extends Relation
         }
        
         return $query;
+    }
+
+    /**
+     * Define a callback to be run against each result model
+     *
+     * @param  Closure $callback
+     * @return static
+     */
+    public function withCallback(Closure $callback): static
+    {
+        $this->callback = $callback;
+        return $this;
     }
 }

--- a/src/Traits/HasAggregateRelationTrait.php
+++ b/src/Traits/HasAggregateRelationTrait.php
@@ -2,6 +2,7 @@
 
 namespace thybag\BonusLaravelRelations\Traits;
 
+use Illuminate\Database\Eloquent\Model;
 use thybag\BonusLaravelRelations\Models\InertModel;
 use thybag\BonusLaravelRelations\Relations\HasAggregate;
 
@@ -13,10 +14,12 @@ trait HasAggregateRelationTrait
      *
      * @param $related - parent model name
      * @param $relation_key - key to group on
+     * @param $sql - aggregate sql query. Equivalent to selectRaw
+     * @param $returnModel - model to be used in place of intertModel
      *
      * @return HasAggregate Relation
      */
-    public function hasAggregate(string $related, string $relation_key = null, string $sql = null)
+    public function hasAggregate(string $related, string $relation_key = null, string $sql = null, ?string $returnModel = null)
     {
         $instance = new $related;
 
@@ -24,6 +27,6 @@ trait HasAggregateRelationTrait
             $relation_key = $this->getForeignKey();
         }
 
-        return new HasAggregate($instance->newQuery(), $this, $relation_key, $sql);
+        return new HasAggregate($instance->newQuery(), $this, $relation_key, $sql, $returnModel);
     }
 }

--- a/src/Traits/HasAggregateRelationTrait.php
+++ b/src/Traits/HasAggregateRelationTrait.php
@@ -12,10 +12,10 @@ trait HasAggregateRelationTrait
      * Return aggregated results in a relation like way.
      * Allows eager loading of aggregate results.
      *
-     * @param $related - parent model name
-     * @param $relation_key - key to group on
-     * @param $sql - aggregate sql query. Equivalent to selectRaw
-     * @param $returnModel - model to be used in place of intertModel
+     * @param string $related - parent model name
+     * @param string|null $relation_key - key to group on
+     * @param string|null $sql - aggregate sql query. Equivalent to selectRaw
+     * @param string|null $returnModel - model to be used in place of intertModel
      *
      * @return HasAggregate Relation
      */

--- a/src/Traits/InertModelTrait.php
+++ b/src/Traits/InertModelTrait.php
@@ -2,6 +2,7 @@
 
 namespace thybag\BonusLaravelRelations\Traits;
 
+use Illuminate\Database\Eloquent\Model;
 use thybag\BonusLaravelRelations\Models\InertModel;
 
 trait InertModelTrait
@@ -11,9 +12,15 @@ trait InertModelTrait
      *
      * @return Model
      */
-    protected function getInertModelInstance()
+    protected function getInertModelInstance(string $useModel = null): Model
     {
-        // Attempt to use provided inertModel if one is set.
+        // If explict model is provided. Use it
+        if (!empty($useModel)) {
+            return new $useModel();
+        }
+
+        // Otherwise attempt to use inertModel from config, or local one
+        // if none is defined
         $model = config('bonus-laravel-relationships.inertModel');
         return !empty($model) ? new $model() : new InertModel();
     }

--- a/src/Traits/InertModelTrait.php
+++ b/src/Traits/InertModelTrait.php
@@ -10,6 +10,7 @@ trait InertModelTrait
     /**
      * Get basic model instance to return as result.
      *
+     * @param string $useModel - Class path of model to use instead of inertModel.
      * @return Model
      */
     protected function getInertModelInstance(string $useModel = null): Model

--- a/tests/Models/Shop.php
+++ b/tests/Models/Shop.php
@@ -2,6 +2,7 @@
 namespace thybag\BonusLaravelRelations\Test\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use thybag\BonusLaravelRelations\Test\Models\CustomInert;
 use thybag\BonusLaravelRelations\Traits\BonusRelationsTrait;
 
 class Shop extends Model
@@ -44,6 +45,21 @@ class Shop extends Model
     public function productTotalsViaRaw()
     {
         return $this->hasAggregate(Product::class)->selectRaw($this->productTotalsSql);
+    }
+
+    public function productTotalsWithCallback()
+    {
+        return $this->hasAggregate(Product::class)
+            ->selectRaw($this->productTotalsSql)
+            ->withCallback(function ($item) {
+                $item->uniqueText = "You have {$item->unique_products} unique products";
+                return $item;
+            });
+    }
+
+    public function productTotalsWithCustomInert()
+    {
+        return $this->hasAggregate(Product::class, 'products.shop_id', $this->productTotalsSql, CustomInert::class);
     }
 
     public function notes()


### PR DESCRIPTION
Adds a new `withCallback(function($item) { return $item; }` on an aggregate relationship allows the definition of post process functions.

This function is run on each result model, and can apply tweaks/changes that are challenging or inefficient to implement in raw SQL. Relationships will still exhibit all normal behaviours.

Other changes
* Can now provide a custom returnModel as the 4th parameter to use instead of the intertModel. Overrides both the base intertModel and one defined by the config.
* Add lint-fix command to composer